### PR TITLE
Change maximum key handle length to 255.

### DIFF
--- a/qubesu2f/const.py
+++ b/qubesu2f/const.py
@@ -111,7 +111,7 @@ U2F_APPID_SIZE = 32  # "application parameter"
 U2F_REGISTER_ID = 0x05  # magic value of the first byte of Register response
 
 P256_POINT_SIZE = 65
-MAX_KH_SIZE = 128
+MAX_KH_SIZE = 255
 
 # Authenticate
 


### PR DESCRIPTION
The constant MAX_KH_SIZE was previously set to 128. At least one U2F token returns a key handle larger than that. According to https://fidoalliance.org/specs/fido-u2f-v1.2-ps-20170411/fido-u2f-raw-message-formats-v1.2-ps-20170411.html#registration-response-message-success , the key handle length is an unsigned byte and the whole range from 0 to 255 is valid.

Equivalently, we could also remove the key handle size checks as a byte value cannot be larger than 255.

This fixes https://github.com/QubesOS/qubes-issues/issues/8120.