### PR TITLE
libfido2 / pam-u2f compatibility

### DIFF
--- a/qubesu2f/proto.py
+++ b/qubesu2f/proto.py
@@ -597,11 +597,9 @@ class CommandAPDURegister(CommandAPDU):
         request_data = untrusted_request_data
         return request_data
 
-    # this is unspecified, but at least chromium seems to include it
+    # this should be zero, but at least chromium and firefox submit a non-zero value; just ignore it
     def verify_p1(self, *, untrusted_p1):
-        # this raises ValueError if untrusted_p1 is not one of the enum values
-        p1 = const.U2F_AUTH(untrusted_p1)
-        return p1
+        return 0
 
     def hexdump_request_data(self):
         return util.hexlify_with_parition(self.request_data,

--- a/systemd/qubes-u2fproxy@.service
+++ b/systemd/qubes-u2fproxy@.service
@@ -4,7 +4,7 @@ ConditionPathExists=/var/run/qubes-service/qubes-u2f-proxy
 
 [Service]
 Type=notify
-ExecStart=/usr/bin/qu2f-proxy %i
+ExecStart=/usr/bin/qu2f-proxy --hid-bus USB %i
 StandardOutput=syslog
 KillMode=process
 Restart=on-failure


### PR DESCRIPTION
These small changes make qubes-u2f work together with pam-u2f (and other software using libfido2).

Note that still a recent version of libfido2 is needed, because before commit https://github.com/Yubico/libfido2/commit/6117603260fb55ba4ea3f515d3801e5ba6669aa5 a manufacturer and product usb info had to be supplied, which the virtual hid device cannot do. This affects debian-11 AppVMs, but not fedora-37 AppVMs.