### PR TITLE
use python-fido2 instead of deprecated python-u2flib-host

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,9 +18,7 @@ introduction and U2F threat model.
 - For Debian template: Debian 10 (stretch) or later
 - For Fedora template: Fedora 35 or later
 - Python 3.5 or later
-- A Python FIDO2/U2F library, one of:
-  - https://github.com/Yubico/python-fido2
-  - https://github.com/Yubico/python-u2flib-host (deprecated)
+- python-fido2 library: https://github.com/Yubico/python-fido2
 - For building manpages: `python3-sphinx`
 
 ### Installation

--- a/README.markdown
+++ b/README.markdown
@@ -18,7 +18,9 @@ introduction and U2F threat model.
 - For Debian template: Debian 10 (stretch) or later
 - For Fedora template: Fedora 35 or later
 - Python 3.5 or later
-- https://github.com/Yubico/python-u2flib-host
+- A Python FIDO2/U2F library, one of:
+  - https://github.com/Yubico/python-fido2
+  - https://github.com/Yubico/python-u2flib-host (deprecated)
 - For building manpages: `python3-sphinx`
 
 ### Installation

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Vcs-Browser: https://github.com/QubesOS/qubes-app-u2f.git
 Package: qubes-u2f
 Architecture: all
 Depends:
- python3-u2flib-host,
+ python3-u2flib-host | python3-fido2,
  ${python3:Depends},
  ${misc:Depends}
 Description: Qubes OS U2F proxy

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Vcs-Browser: https://github.com/QubesOS/qubes-app-u2f.git
 Package: qubes-u2f
 Architecture: all
 Depends:
- python3-u2flib-host | python3-fido2,
+ python3-fido2,
  ${python3:Depends},
  ${misc:Depends}
 Description: Qubes OS U2F proxy

--- a/qubesu2f/tests/conformance.py
+++ b/qubesu2f/tests/conformance.py
@@ -27,9 +27,9 @@ import time
 import unittest
 
 try:
-    import u2flib_host.u2f  # pylint: disable=import-error
-except ImportError:
     import fido2  # pylint: disable=import-error
+except ImportError:
+    import u2flib_host.u2f  # pylint: disable=import-error
 
 from .. import const
 from .. import proto

--- a/qubesu2f/tests/conformance.py
+++ b/qubesu2f/tests/conformance.py
@@ -26,7 +26,10 @@ import os
 import time
 import unittest
 
-import u2flib_host.u2f  # pylint: disable=import-error
+try:
+    import u2flib_host.u2f  # pylint: disable=import-error
+except ImportError:
+    import fido2  # pylint: disable=import-error
 
 from .. import const
 from .. import proto

--- a/qubesu2f/tools/__init__.py
+++ b/qubesu2f/tools/__init__.py
@@ -30,9 +30,9 @@ import pathlib
 import sys
 
 try:
-    import u2flib_host.u2f  # pylint: disable=import-error
-except ImportError:
     import fido2  # pylint: disable=import-error
+except ImportError:
+    import u2flib_host.u2f  # pylint: disable=import-error
 
 from .. import const
 from .. import proto

--- a/qubesu2f/tools/__init__.py
+++ b/qubesu2f/tools/__init__.py
@@ -29,7 +29,10 @@ import os
 import pathlib
 import sys
 
-import u2flib_host.u2f  # pylint: disable=import-error
+try:
+    import u2flib_host.u2f  # pylint: disable=import-error
+except ImportError:
+    import fido2  # pylint: disable=import-error
 
 from .. import const
 from .. import proto

--- a/rpm_spec/qubes-u2f.spec.in
+++ b/rpm_spec/qubes-u2f.spec.in
@@ -16,7 +16,7 @@ BuildRequires:  make
 BuildRequires:  systemd
 
 Requires:	python%{python3_pkgversion}
-Requires:	(python%{python3_pkgversion}-u2flib-host or python%{python3_pkgversion}-fido2)
+Requires:	python%{python3_pkgversion}-fido2
 
 %description
 Qubes OS U2F proxy

--- a/rpm_spec/qubes-u2f.spec.in
+++ b/rpm_spec/qubes-u2f.spec.in
@@ -16,7 +16,7 @@ BuildRequires:  make
 BuildRequires:  systemd
 
 Requires:	python%{python3_pkgversion}
-Requires:	python%{python3_pkgversion}-u2flib-host
+Requires:	(python%{python3_pkgversion}-u2flib-host or python%{python3_pkgversion}-fido2)
 
 %description
 Qubes OS U2F proxy

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
         url='https://github.com/QubesOS/qubes-app-u2f',
         requires=[
             'python_fido2',
-        ]
+        ],
         packages=setuptools.find_packages(),
         package_data={
             'qubesu2f.tests': ['*.xpi'],

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ if __name__ == '__main__':
         license='GPL2+',
         url='https://github.com/QubesOS/qubes-app-u2f',
         requires=[
-            'python_u2flib_host',
-        ],
+            'python_fido2',
+        ]
         packages=setuptools.find_packages(),
         package_data={
             'qubesu2f.tests': ['*.xpi'],


### PR DESCRIPTION
as mentioned in [#5501](https://github.com/QubesOS/qubes-issues/issues/5501)