### PR TITLE
Make CTAP2/FIDO2 work with real browsers (CBOR framing, rp.name, ClientPIN keys, discoverable creds)

### DIFF
--- a/qubesctap/client/hidemu.py
+++ b/qubesctap/client/hidemu.py
@@ -305,6 +305,10 @@ class CTAPHIDDevice(uhid.UHIDDevice):
     async def _handle_ctaphid_request(self, cid, untrusted_cmd, ctaphid, protocol):
         self.log.getChild('ctaphid').debug(
             'handle_ctaphid_%s(cid=%#08x, data=...)', ctaphid, cid)
+        # the response must use the same CTAPHID command as the request:
+        # CTAPHID_CBOR for CTAP2, CTAPHID_MSG for CTAP1/U2F (CTAP spec
+        # 11.2.9.1.1, 11.2.9.1.2)
+        resp_cmd = CTAPHID.CBOR if ctaphid == "cbor" else CTAPHID.MSG
         try:
             request = RequestWrapper.from_bytes(untrusted_cmd)
             request.raise_error(protocol=protocol)
@@ -312,7 +316,7 @@ class CTAPHIDDevice(uhid.UHIDDevice):
                 'handle_ctaphid_%s(cid=%#08x) %s=%r',
                 ctaphid, cid, ctaphid, request.data)
             handle = getattr(self, f'handle_{protocol}_' + request.name)
-            await self.write_ctaphid_response(cid, CTAPHID.MSG,
+            await self.write_ctaphid_response(cid, resp_cmd,
                                               bytes(await handle(request)))
         except ApduError as err:
             self.log.getChild('ctaphid').info(

--- a/qubesctap/client/qctap_proxy.py
+++ b/qubesctap/client/qctap_proxy.py
@@ -153,12 +153,22 @@ class CTAPHIDQrexecDevice(hidemu.CTAPHIDDevice):
 
     async def handle_fido2_get_assertion(self, cbor):
         self.log.getChild('ctap').debug('handle_fido2_get_assertion()')
-        self.log.getChild('ctap').debug('%s', str(list(cbor.qrexec_args)))
-        for qrexec_arg in cbor.qrexec_args:
+        qrexec_args = list(cbor.qrexec_args)
+        self.log.getChild('ctap').debug('%s', str(qrexec_args))
+        if qrexec_args:
+            rpcnames = [f'u2f.Authenticate+{arg}' for arg in qrexec_args]
+        else:
+            # Discoverable credential: an empty allowList names no credential,
+            # so there is no per-credential qrexec argument. Call the service
+            # without one; the backend then skips the allowList check and lets
+            # the authenticator pick the resident credential (still gated by
+            # qrexec policy, PIN and user presence).
+            rpcnames = ['u2f.Authenticate']
+        for rpcname in rpcnames:
             # pylint: disable=broad-except
             try:
                 response = await self.qrexec_transaction(
-                    cbor, rpcname=f'u2f.Authenticate+{qrexec_arg}')
+                    cbor, rpcname=rpcname)
                 return CborResponseWrapper.from_bytes(
                     response, expected_type=AssertionResponse)
             except Exception as err:

--- a/qubesctap/ctap2.py
+++ b/qubesctap/ctap2.py
@@ -37,6 +37,31 @@ from fido2.webauthn import PublicKeyCredentialRpEntity, Aaguid
 from qubesctap.util import qrexec_arg
 
 
+@dataclass(eq=False, frozen=True, kw_only=True)
+class LenientRpEntity(PublicKeyCredentialRpEntity):
+    """A relying-party entity that tolerates a missing ``name``.
+
+    At the CTAP2 authenticatorMakeCredential level the ``name`` in the rp
+    map is optional (Firefox, for instance, omits it), but fido2's
+    PublicKeyCredentialRpEntity marks it required -- so the whole request
+    fails to parse and is rejected before it ever reaches the authenticator.
+
+    When ``name`` is absent we default it to the rp ``id``. The value must be
+    a NON-EMPTY text string: the sys-usb backend re-serialises the request to
+    the token through fido2, whose _DataClassMapping.__getitem__ turns an
+    empty string into ``[]`` (a vacuous all() over the empty sequence); an
+    array where the key expects a text string yields
+    CTAP2_ERR_CBOR_UNEXPECTED_TYPE (0x11). The id is always present and
+    non-empty, so it side-steps that.
+    """
+    name: str = ""
+
+    def __post_init__(self):
+        super().__post_init__()
+        if not self.name and self.id:
+            object.__setattr__(self, "name", self.id)
+
+
 @dataclass(eq=False, frozen=True)
 class Ctap2Dataclass(_CborDataObject):
     """
@@ -287,7 +312,7 @@ class MakeCredential(Ctap2Request):
     """
     # pylint: disable=invalid-name,too-many-instance-attributes
     client_data_hash: bytes
-    rp: PublicKeyCredentialRpEntity
+    rp: LenientRpEntity
     user: dict
     pub_key_cred_params: List[Mapping[str, Any]]
     exclude_list: Optional[List[Mapping[str, Any]]]
@@ -438,6 +463,22 @@ class ClientPIN(Ctap2Request):
     pin_hash_enc: Optional[bytes]
     permissions: Optional[int]
     permissions_rpid: Optional[str]
+
+    @classmethod
+    def _get_field_key(cls, field: Field) -> int:
+        # The authenticatorClientPIN CBOR map is not contiguous: it skips keys
+        # 0x07 and 0x08, so permissions is 0x09 and rpId is 0x0A (CTAP2.1
+        # 6.5.5). The default positional index+1 map would assign them 7/8,
+        # dropping them on both parse and re-serialisation for the
+        # getPinUvAuthTokenUsingPin/UvWithPermissions sub-commands and breaking
+        # PIN entry on every authenticator that advertises pinUvAuthToken.
+        # (execute() already emits them at 9/10 via args(); this keeps
+        # from_dict/to_dict consistent with that.)
+        if field.name == "permissions":
+            return 0x09
+        if field.name == "permissions_rpid":
+            return 0x0A
+        return super()._get_field_key(field)
 
     def execute(self, ctap: Ctap2) -> ClientPINResponse:
         """

--- a/qubesctap/sys_usb/qctap_get_assertion.py
+++ b/qubesctap/sys_usb/qctap_get_assertion.py
@@ -46,7 +46,7 @@ async def main_async(args=None, mux=default_mux):
     request = RequestWrapper.from_bytes(untrusted_request)
 
     allow_list = list(request.qrexec_args)
-    if args.credential_id_hash is not None:
+    if args.credential_id_hash:
         if args.credential_id_hash not in allow_list:
             return 1
         request.trim_allow_list(args.credential_id_hash)

--- a/qubesctap/tests/test_ctap2.py
+++ b/qubesctap/tests/test_ctap2.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+#
+# The Qubes OS Project, https://www.qubes-os.org
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301,
+# USA.
+from fido2 import cbor
+
+from qubesctap.ctap2 import Ctap2Request, ClientPIN
+from qubesctap.protocol import RequestWrapper
+
+
+def _make_credential(rp: dict) -> bytes:
+    return bytes([0x01]) + cbor.encode({
+        1: b"\x00" * 32,
+        2: rp,
+        3: {"id": b"user", "name": "user"},
+        4: [{"alg": -7, "type": "public-key"}],
+        7: {"rk": True},
+    })
+
+
+def test_makecredential_rp_without_name_defaults_to_id():
+    """Firefox omits rp.name; fido2 marks it required. It must parse, with
+    name defaulting to the (always present, non-empty) rp id."""
+    req = Ctap2Request.from_bytes(_make_credential({"id": "webauthn.io"}))
+    assert req.rp.id == "webauthn.io"
+    assert req.rp.name == "webauthn.io"
+
+
+def test_makecredential_rp_with_name_is_preserved():
+    req = Ctap2Request.from_bytes(
+        _make_credential({"id": "webauthn.io", "name": "Example"}))
+    assert req.rp.name == "Example"
+
+
+def test_makecredential_rp_name_reserializes_as_text_string():
+    """The re-serialised rp.name (what the proxy forwards) must be a text
+    string, not [] -- fido2 maps an empty string to [] via a vacuous all(),
+    which the token rejects with CTAP2_ERR_CBOR_UNEXPECTED_TYPE (0x11)."""
+    wrapper = RequestWrapper.from_bytes(_make_credential({"id": "webauthn.io"}))
+    rp = cbor.decode(bytes(wrapper)[1:])[2]
+    assert rp["name"] == "webauthn.io"
+    assert isinstance(rp["name"], str)
+
+
+def _client_pin(extra: dict) -> bytes:
+    base = {1: 2, 2: 0x09, 3: {1: 2}, 6: b"\xcc" * 32}
+    base.update(extra)
+    return bytes([0x06]) + cbor.encode(base)
+
+
+def test_clientpin_permissions_use_cbor_keys_9_and_10():
+    """authenticatorClientPIN skips CBOR keys 0x07/0x08: permissions is 0x09
+    and rpId is 0x0A. The positional index+1 map would use 7/8 and silently
+    drop them, breaking PIN on CTAP2.1 (pinUvAuthToken) authenticators."""
+    wrapper = RequestWrapper.from_bytes(
+        _client_pin({9: 0x03, 10: "webauthn.io"}))
+    req = wrapper.data
+    assert isinstance(req, ClientPIN)
+    assert req.permissions == 0x03
+    assert req.permissions_rpid == "webauthn.io"
+
+    encoded = cbor.decode(bytes(wrapper)[1:])
+    assert encoded[9] == 0x03
+    assert encoded[10] == "webauthn.io"
+    assert 7 not in encoded and 8 not in encoded
+
+
+def test_clientpin_get_pin_token_without_permissions_unaffected():
+    """Legacy getPinToken (0x05) carries no permissions; must still parse."""
+    req = Ctap2Request.from_bytes(
+        bytes([0x06]) + cbor.encode({1: 2, 2: 0x05, 3: {1: 2}, 6: b"\xcc" * 16}))
+    assert isinstance(req, ClientPIN)
+    assert req.sub_cmd == 0x05
+    assert req.permissions is None
+    assert req.permissions_rpid is None

--- a/qubesctap/tests/test_hidemu.py
+++ b/qubesctap/tests/test_hidemu.py
@@ -199,3 +199,22 @@ async def test_handle_hid_output_finished_channel_schedules_execute(monkeypatch)
 
     # And since PING handler should run, it should try to write a response
     dev.write_ctaphid_response.assert_awaited()
+@pytest.mark.asyncio
+async def test_cbor_request_answered_with_cbor_command():
+    """
+    A CTAPHID_CBOR request must be answered on CTAPHID_CBOR, not
+    CTAPHID_MSG (CTAP spec 11.2.9.1.2; QubesOS/qubes-issues#10981).
+    """
+    dev = hidemu.CTAPHIDDevice()
+    dev.write_ctaphid_response = AsyncMock()
+    # authenticatorGetInfo response payload: CTAP2_OK + empty CBOR map
+    dev.handle_fido2_get_info = AsyncMock(return_value=b"\x00\xa0")
+
+    # 0x04 = authenticatorGetInfo
+    await dev.handle_ctaphid_cbor(1, b"\x04")
+
+    dev.write_ctaphid_response.assert_awaited_once()
+    cid, cmd, data = dev.write_ctaphid_response.await_args.args
+    assert cid == 1
+    assert cmd == hidemu.CTAPHID.CBOR
+    assert data == b"\x00\xa0"

--- a/qubesctap/tests/test_qctap_proxy.py
+++ b/qubesctap/tests/test_qctap_proxy.py
@@ -238,3 +238,29 @@ def test_main_calls_asyncio_run(monkeypatch):
 
     entry.main_async.assert_called_once_with(None)
     run_mock.assert_called_once_with(sentinel)
+
+@pytest.mark.asyncio
+async def test_get_assertion_discoverable_uses_argless_rpc(monkeypatch):
+    """A GetAssertion with an empty allowList (discoverable credential) has no
+    per-credential qrexec argument, so it must invoke u2f.Authenticate without
+    one instead of silently doing nothing."""
+    from fido2 import cbor
+
+    dev = qctap_proxy.CTAPHIDQrexecDevice("some-vm", name="x")
+
+    # GetAssertion: rp_id (1) + client_data_hash (2) + options (5); NO allowList
+    request = RequestWrapper.from_bytes(
+        bytes([0x02]) + cbor.encode(
+            {1: "webauthn.io", 2: b"\x00" * 32, 5: {"up": True}}))
+
+    captured = {}
+
+    async def fake_qrexec(_req, rpcname):
+        captured["rpcname"] = rpcname
+        return get_response_bytes("GetAssertion")
+
+    monkeypatch.setattr(dev, "qrexec_transaction", fake_qrexec)
+
+    await dev.handle_fido2_get_assertion(request)
+
+    assert captured["rpcname"] == "u2f.Authenticate"


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#10981.

A series of fixes that make CTAP2/FIDO2 (including passwordless / discoverable
credentials) work through the proxy with real browsers. All were found and
verified end-to-end driving Firefox against demo.yubico.com through a
Fedora-40 client qube and a Debian sys-usb, with a **FIDO_2_0** YubiKey 5
(legacy `getPinToken`) and a **FIDO_2_1** YubiKey 5 Nano (`pinUvAuthToken`
with permissions). Each commit adds regression tests; the full suite passes.

### 1. Answer `CTAPHID_CBOR` requests with `CTAPHID_CBOR` (original commit)

`_handle_ctaphid_request` hard-coded `CTAPHID.MSG` on the response, so replies
to CTAP2/CBOR requests were framed as `CTAPHID_MSG` (0x83) instead of
`CTAPHID_CBOR` (0x90). Lenient clients (Chromium) tolerate it, but
spec-compliant ones (Firefox's authenticator-rs, libfido2, python-fido2)
reject the frame and silently fall back to U2F — so every CTAP2 feature
(passkeys, PIN/UV, hmac-secret) was unusable. Present since the 2023 migration
to fido2.

### 2. Parse `MakeCredential` without `rp.name`

`MakeCredential.rp` uses fido2's `PublicKeyCredentialRpEntity`, whose `name`
is required. Firefox omits `rp.name` at the authenticator level (it is
optional there), so the whole request failed to parse (`Error parsing field
rp`) and was rejected before reaching the key. A `LenientRpEntity` defaults a
missing name to the rp `id` — a non-empty text string, which also matters on
re-serialisation: fido2 encodes an empty string as `[]` (a vacuous `all()`
over the empty sequence), which the token rejects with
`CTAP2_ERR_CBOR_UNEXPECTED_TYPE` (0x11).

### 3. Fix `ClientPIN` CBOR key mapping (permissions/rpId → 0x09/0x0A)

`Ctap2Dataclass._get_field_key` derives keys from field position (`index+1`),
but the `authenticatorClientPIN` map is not contiguous — it skips 0x07/0x08,
so `permissions` is 0x09 and `rpId` is 0x0A (CTAP2.1 §6.5.5). The positional
map placed them at 7/8, so `getPinUvAuthTokenUsingPin/UvWithPermissions` had
its permissions silently dropped and every `pinUvAuthToken`-capable (CTAP2.1)
authenticator returned `CTAP2_ERR_MISSING_PARAMETER` — breaking PIN entry for
registration/authentication on modern keys. `execute()` already emits 9/10
(via `args(..., None, None, permissions, permissions_rpid)`); a `ClientPIN`
`_get_field_key` override makes `from_dict`/`to_dict` agree.

### 4. Support discoverable-credential (empty allowList) assertions

A passwordless `GetAssertion` has an empty allowList and therefore no
per-credential qrexec argument. `handle_fido2_get_assertion` iterated over the
empty argument list, issued no qrexec call at all, and returned a fabricated
`INVALID_COMMAND` — the request never reached the key. It now falls back to a
single argument-less `u2f.Authenticate`, letting the authenticator select the
resident credential (still gated by qrexec policy, PIN and user presence). The
backend handler also rejected the argument-less call, because an absent
`QREXEC_SERVICE_ARGUMENT` is the empty string (not `None`) and failed the
`not in allow_list` check; it now tests truthiness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
